### PR TITLE
more portable shebang

### DIFF
--- a/spotifycli/spotifycli.py
+++ b/spotifycli/spotifycli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/env python
 
 import sys, getopt, dbus
 from subprocess import Popen, PIPE


### PR DESCRIPTION
On my machine (Mac OS), I have `/usr/local/bin/python`, which is symlinked to python 3 managed with homebrew. I'd like to use that version instead of what comes default at `/usr/bin/python`.

See: https://stackoverflow.com/questions/17846908/proper-shebang-for-python-script/17846946

/cc @pwittchen 