### PR TITLE
Switch to argparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,23 +36,25 @@ spotifycli
 use one of the following parameters:
 
 ```
---help              shows help
---version           shows version
---status            shows status (song name and artist)
---status-short      shows status in a short way
---song              shows the current song name
---song-short        shows the current song name in a short way
---artist            shows the current artist
---artist-short      shows the current artist in a short way
---album             shows the current album
---playback-status   shows the current playback status (UTF-8)
---play              plays the song
---pause             pauses the song
---playpause         plays or pauses the song (toggles a state)
---next              plays the next song
---prev              plays the previous song
---volumeup          increases sound volume
---volumedown        decreases sound volume
+--help                show this help message and exit
+--version             show program's version number and exit
+--status              shows status (song name and artist)
+--status-short        shows status in a short way
+--song                shows the current song
+--song-short [SONG_LEN]
+                      shows the current song in a short way (default: 10)
+--artist              shows the current artist
+--artist-short [ARTIST_LEN]
+                      shows the current artist in a short way (default: 15)
+--album               shows the current album
+--playback-status     shows the current playback status (UTF-8)
+--play                plays the song
+--pause               pauses the song
+--playpause           plays or pauses the song (toggles a state)
+--next                plays the next song
+--prev                plays the previous song
+--volumeup            increases sound volume
+--volumedown          decreases sound volume
 ```
 
 solving problems

--- a/spotifycli/spotifycli.py
+++ b/spotifycli/spotifycli.py
@@ -2,91 +2,86 @@
 # -*- coding: utf-8 -*-
 
 import sys
-import getopt
+import argparse
 import dbus
 from subprocess import Popen, PIPE
 from version import __version__
 
 
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', action='version', version=__version__)
+parser.add_argument('--status', dest='status', action='store_true',
+                    help='shows status (song name and artist)')
+parser.add_argument('--status-short', dest='status_short', action='store_true',
+                    help='shows status in a short way')
+parser.add_argument('--song', dest='song', action='store_true',
+                    help='shows the current song')
+parser.add_argument('--song-short', dest='song_short', nargs='?', const=10,
+                    type=int, metavar='SONG_LEN',
+                    help='shows the current song in a short way \
+                            (default: 10)')
+parser.add_argument('--artist', dest='artist', action='store_true',
+                    help='shows the current artist')
+parser.add_argument('--artist-short', dest='artist_short', nargs='?', const=15,
+                    type=int, metavar='ARTIST_LEN',
+                    help='shows the current artist in a short way \
+                            (default: 15)')
+parser.add_argument('--album', dest='album', action='store_true',
+                    help='shows the current album')
+parser.add_argument('--playback-status', dest='playback_status',
+                    action='store_true',
+                    help='shows the current playback status (UTF-8)')
+parser.add_argument('--play', dest='play', action='store_true',
+                    help='plays the song')
+parser.add_argument('--pause', dest='pause', action='store_true',
+                    help='pauses the song')
+parser.add_argument('--playpause', dest='playpause', action='store_true',
+                    help='plays or pauses the song (toggles a state)')
+parser.add_argument('--next', dest='next', action='store_true',
+                    help='plays the next song')
+parser.add_argument('--prev', dest='prev', action='store_true',
+                    help='plays the previous song')
+parser.add_argument('--volumeup', dest='volumeup', action='store_true',
+                    help='increases sound volume')
+parser.add_argument('--volumedown', dest='volumedown',
+                    action='store_true', help='decreases sound volume')
+
+
 def main():
-    try:
-        opts, args = getopt.getopt(sys.argv[1:], "", ["help", "status",
-                                                      "status-short",
-                                                      "song", "song-short",
-                                                       "album", "artist",
-                                                       "artist-short",
-                                                       "playback-status",
-                                                       "play", "pause",
-                                                       "playpause", "next",
-                                                       "prev", "volumeup",
-                                                       "volumedown",
-                                                       "version"])
-    except getopt.GetoptError:
-        show_help()
-        sys.exit(2)
-
-    for opt, arg in opts:
-        if opt in ("--help"):
-            show_help()
-        if opt in ("--version"):
-            show_version()
-        elif opt == "--status":
-            show_current_status()
-        elif opt == "--status-short":
-            show_current_status_short()
-        elif opt == "--song":
-            show_current_song()
-        elif opt == "--song-short":
-            show_current_song_short()
-        elif opt == "--artist":
-            show_current_artist()
-        elif opt == "--artist-short":
-            show_current_artist_short()
-        elif opt == "--album":
-            show_current_album()
-        elif opt == "--playback-status":
-            show_current_playback_status()
-        elif opt == "--play":
-            perform_spotify_action("Play")
-        elif opt == "--pause":
-            perform_spotify_action("Pause")
-        elif opt == "--playpause":
-            perform_spotify_action("PlayPause")
-        elif opt == "--next":
-            perform_spotify_action("Next")
-        elif opt == "--prev":
-            perform_spotify_action("Previous")
-        elif opt == "--volumeup":
-            control_volume("+5%")
-        elif opt == "--volumedown":
-            control_volume("-5%")
-
-
-def show_help():
-    print(
-        '\n  spotify-cli is a command line interface for Spotify on Linux\n\n'
-        '  usage:\n'
-        '    --help\t\tshows help\n'
-        '    --version\t\tshows version\n'
-        '    --status\t\tshows status (song name and artist)\n'
-        '    --status-short\tshows status in a short way\n'
-        '    --song\t\tshows the current song name\n'
-        '    --song-short\tshows the current song name in a short way\n'
-        '    --artist\t\tshows the current artist\n'
-        '    --artist-short\tshows the current artist in a short way\n'
-        '    --album\t\tshows the current album\n'
-        '    --playback-status\tshows the current playback status (UTF-8)\n'
-        '    --play\t\tplays the song\n'
-        '    --pause\t\tpauses the song\n'
-        '    --playpause\t\tplays or pauses the song (toggles a state)\n'
-        '    --next\t\tplays the next song\n'
-        '    --prev\t\tplays the previous song\n'
-        '    --volumeup\t\tincreases sound volume\n'
-        '    --volumedown\tdecreases sound volume\n')
-
-
-def show_version():
-    print(__version__)
+    if len(sys.argv) == 1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+    args = parser.parse_args()
+    if args.status:
+        show_current_status()
+    elif args.status_short:
+        show_current_status_short()
+    elif args.song:
+        show_current_song()
+    elif args.song_short:
+        show_current_song_short(args.song_short)
+    elif args.artist:
+        show_current_artist()
+    elif args.artist_short:
+        show_current_artist_short(args.artist_short)
+    elif args.album:
+        show_current_album()
+    elif args.playback_status:
+        show_current_playback_status()
+    elif args.play:
+        perform_spotify_action("Play")
+    elif args.pause:
+        perform_spotify_action("Pause")
+    elif args.playpause:
+        perform_spotify_action("PlayPause")
+    elif args.next:
+        perform_spotify_action("Next")
+    elif args.prev:
+        perform_spotify_action("Previous")
+    elif args.volumeup:
+        control_volume("+5%")
+    elif args.volumedown:
+        control_volume("-5%")
 
 
 def get_spotify_property(p):
@@ -127,9 +122,9 @@ def show_current_song():
     print("%s" % title)
 
 
-def show_current_song_short():
+def show_current_song_short(length):
     _, title = get_current_song()
-    title = title[:10] + (title[10:] and '...')
+    title = title[:length] + (title[length:] and '...')
     print("%s" % title)
 
 
@@ -138,9 +133,9 @@ def show_current_artist():
     print("%s" % artist)
 
 
-def show_current_artist_short():
+def show_current_artist_short(length):
     artist, _ = get_current_song()
-    artist = artist[:15] + (artist[15:] and '...')
+    artist = artist[:length] + (artist[length:] and '...')
     print("%s" % artist)
 
 


### PR DESCRIPTION
Closes #25 I've gone with `argparse` instead of `click`, since I already have experience with `argparse` and it's easier to understand IMO.

- Add configuration options for --song-short and --artist-short. This will
especially be useful with the tmux spotify plugin to configure the length of
the song name and the artist name for smaller/wider screens.

- ~Introduce short options (supersedes #27)~

- Update README

(This currently builds on top of #26. If #26 gets merged I'll rebase this, so it only includes the second commit. Or we can just use this PR and drop #26)