### PR TITLE
Added function to display the image url of the album, and support third-party clients

### DIFF
--- a/spotifycli/spotifycli.py
+++ b/spotifycli/spotifycli.py
@@ -19,8 +19,10 @@ def main():
     if len(sys.argv) == 1:
         start_shell()
         return 0
-
+    
+    global client
     args = add_arguments()
+    client = args.client
     if args.version:
         show_version()
     elif args.status:
@@ -85,6 +87,8 @@ def add_arguments():
     parser = argparse.ArgumentParser(description=__doc__)
     for argument in get_arguments():
         parser.add_argument(argument[0], help=argument[1], action="store_true")
+    parser.add_argument("--client", action="store", dest="client",
+                        help="sets client's dbus name", default="spotify")
     return parser.parse_args()
 
 
@@ -186,7 +190,7 @@ def get_spotify_property(spotify_property):
     try:
         session_bus = dbus.SessionBus()
         spotify_bus = session_bus.get_object(
-            "org.mpris.MediaPlayer2.spotify",
+            "org.mpris.MediaPlayer2.%s" % client,
             "/org/mpris/MediaPlayer2")
         spotify_properties = dbus.Interface(
             spotify_bus,
@@ -200,9 +204,9 @@ def get_spotify_property(spotify_property):
 
 
 def perform_spotify_action(spotify_command):
-    Popen('dbus-send --print-reply --dest=org.mpris.MediaPlayer2.spotify '
+    Popen('dbus-send --print-reply --dest=org.mpris.MediaPlayer2."%s" '
           '/org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player."%s"' %
-          spotify_command, shell=True, stdout=PIPE)
+          client, spotify_command, shell=True, stdout=PIPE)
 
 
 def control_volume(volume_percent):

--- a/spotifycli/spotifycli.py
+++ b/spotifycli/spotifycli.py
@@ -41,6 +41,8 @@ def main():
         show_playback_status()
     elif args.lyrics:
         show_lyrics()
+    elif args.arturl:
+        show_art_url()
     elif args.play:
         perform_spotify_action("Play")
     elif args.pause:
@@ -96,6 +98,7 @@ def get_arguments():
         ("--artist", "shows artist name"),
         ("--artistshort", "shows artist name in a short way"),
         ("--album", "shows album name"),
+        ("--arturl", "shows album image url"),
         ("--playbackstatus", "shows playback status"),
         ("--play", "plays the song"),
         ("--pause", "pauses the song"),
@@ -175,6 +178,9 @@ def show_album():
     metadata = get_spotify_property("Metadata")
     print("%s" % metadata['xesam:album'])
 
+def show_art_url():
+    metadata = get_spotify_property("Metadata")
+    print("%s" % metadata['mpris:artUrl'])
 
 def get_spotify_property(spotify_property):
     try:

--- a/spotifycli/spotifycli.py
+++ b/spotifycli/spotifycli.py
@@ -204,9 +204,10 @@ def get_spotify_property(spotify_property):
 
 
 def perform_spotify_action(spotify_command):
-    Popen('dbus-send --print-reply --dest=org.mpris.MediaPlayer2."%s" '
+    Popen('dbus-send --print-reply --dest=org.mpris.MediaPlayer2."%s" ' % 
+          client + 
           '/org/mpris/MediaPlayer2 org.mpris.MediaPlayer2.Player."%s"' %
-          client, spotify_command, shell=True, stdout=PIPE)
+          spotify_command, shell=True, stdout=PIPE)
 
 
 def control_volume(volume_percent):


### PR DESCRIPTION
I use this tool for myself, and added the functions I need;)
This PR adds features:
- display the URL of the album image with arg `--arturl.` I use this for Dunst notifications.
- ability to work with third-party Spotify clients. I don't use the official Spotify Desktop app, but the dbus name “spotify” is hardcoded. Now with the `--client clientname` argument, you can use another client with dbus mpris support, for example [ncspot](https://github.com/hrkfdn/ncspot), [spotifyd](https://github.com/Spotifyd/spotifyd), [Mopidy](https://github.com/mopidy/mopidy)