### PR TITLE
Changed version check to all Python 3 versions, not just 3.7+

### DIFF
--- a/spotifycli/spotifycli.py
+++ b/spotifycli/spotifycli.py
@@ -9,7 +9,7 @@ import dbus
 import lyricwikia
 from subprocess import Popen, PIPE, check_output
 
-if sys.version_info > (3, 6):
+if sys.version_info[0] >= 3:
     from .version import __version__
 else:
     from version import __version__
@@ -60,7 +60,7 @@ def main():
 def start_shell():
     while(True):
         try:
-            if sys.version_info > (3, 6):
+            if sys.version_info[0] >= 3:
                 command = input('spotify > ')
             else:
                 command = raw_input('spotify > ')


### PR DESCRIPTION
The version-guarded code chunks in `spotifycli.py` fail to run on any Python version >2, not just >3.6 ([source](https://docs.python.org/3.5/whatsnew/3.0.html)).

This PR updates the check to prevent errors when installing the package with eg. Python 3.5 instead of Python 3.7.