### PR TITLE
Add strip method to remove blank spaces in input

### DIFF
--- a/spotifycli/spotifycli.py
+++ b/spotifycli/spotifycli.py
@@ -56,7 +56,7 @@ def main():
 def start_shell():
     while True:
         try:
-            command = input('spotify > ')
+            command = input('spotify > ').strip()
         except EOFError:
             print("Have a nice day!")
             exit(0)


### PR DESCRIPTION
This solves the case in which a user missclicks the spacebar before (or after) the input command, making the intended command as invalid. It's a very minor thing, but happened to me lol