### PR TITLE
fix command name in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ start the official Spotify desktop app
 run the following command from your terminal:
 
 ```
-spotifycli
+spoticli
 ```
 
 use one of the following parameters:


### PR DESCRIPTION
must have been some legacy instruction -- but just tried this out, and it added the command `spoticli` not `spotifycli`. this commit just fixes that reference