### PR TITLE
Switch to pure python library for dbus

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,22 +75,6 @@ if you don't use any parameters, you'll enter the shell mode, where you'll be ab
 solving problems
 ----------------
 
-### dbus
-
-When you've seen the following error:
-
-```
-No module named dbus
-```
-
-Then try to install `python-dbus`! On Ubuntu you can do it as follows:
-
-```
-sudo apt-get install python-dbus
-```
-
-If you are using another distro, then try to install `python-dbus` with your package manager.
-
 ### lyricwikia
 
 When, you're missing `lyricwikia` dependency, run the following command:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 autopep8
+jeepney
+lyricwikia
 pycodestyle
 pylint
 setuptools
 twine
-lyricwikia

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     url='https://github.com/pwittchen/spotify-cli-linux',
     license='GPL 3.0',
     packages=['spotifycli'],
-    install_requires=['lyricwikia'],
+    install_requires=['jeepney', 'lyricwikia'],
     entry_points={
         "console_scripts": ['spotifycli = spotifycli.spotifycli:main']
     },


### PR DESCRIPTION
Using the CLI requires system-level dbus packages to be installed, which vary by distro and can sometimes cause problems even when installed if trying to run `spotifycli` in an isolated env (like installing with pipx or uv). To sidestep this issue, switch to using `jeepney`, a pure python implementation of the dbus interface. Since it is lower level, the logic ends up a little bit more complex. This could be improved, but since the changes are still quite small it didn't feel worthwhile at this point.

Closes #53.

I have written a script to test the output of all the supported CLI endpoints, but writing stable tests would require a bigger refactor, so I won't add it to the commit, I'll just paste it in here (since it doesn't rely on mocking the dbus response and instead requires exact setup).

```python
import io
import sys
from contextlib import redirect_stdout
from unittest.mock import patch

from spotifycli.spotifycli import main

def test_main():

    cases = (
        ("--status", "Tindersticks - Travelling Light\n"),
        ("--statusshort", "Tindersticks - Travelling...\n"),
        ("--statusposition", "Tindersticks - Travelling Light (00:07/04:51)\n"),
        ("--song", "Travelling Light\n"),
        ("--songshort", "Travelling...\n"),
        ("--artist", "Tindersticks\n"),
        ("--artistshort", "Tindersticks\n"),
        ("--album", "Tindersticks\n"),
        ("--position", "(00:07/04:51)\n"),
        ("--playbackstatus", "▮▮\n"),
        ("--lyrics", "lyrics not found\n"),
        ("--arturl", "https://i.scdn.co/image/ab67616d0000b273cdd1aabdf50a42ca4556d31d\n"),
    )

    for flag, expected in cases:
        f = io.StringIO()
        with redirect_stdout(f), patch.object(sys, 'argv', ['spotifycli', '--client', 'spotify', flag]):
            main()
            result = f.getvalue()
            assert result == expected
```