### PR TITLE
Add --songuri and --listuri to enable playing a song or playlist Uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ use one of the following parameters:
 --playpause       plays or pauses the song (toggles a state)
 --next            plays the next song
 --prev            plays the previous song
---openuri OPENURI plays the track at the provided Uri
+--songuri OPENURI plays the track at the provided Uri
+--listuri OPENURI plays the playlist at the provided Uri
 --client CLIENT   sets client's dbus name
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ use one of the following parameters:
 --playpause       plays or pauses the song (toggles a state)
 --next            plays the next song
 --prev            plays the previous song
+--openuri OPENURI plays the track at the provided Uri
 --client CLIENT   sets client's dbus name
 ```
 

--- a/spotifycli/spotifycli.py
+++ b/spotifycli/spotifycli.py
@@ -58,9 +58,10 @@ def main():
         perform_spotify_action("Next")
     elif args.prev:
         perform_spotify_action("Previous")
-    elif args.openuri:
-        perform_spotify_action("OpenUri", f"string:spotify:track:{args.openuri}")
-
+    elif args.songuri:
+        perform_spotify_action("OpenUri", f"string:spotify:track:{args.songuri}")
+    elif args.listuri:
+        perform_spotify_action("OpenUri", f"string:spotify:playlist:{args.listuri}")
 
 def start_shell():
     while True:
@@ -113,7 +114,8 @@ def get_arguments():
         ("--lyrics", "shows the lyrics for the song", False),
         ("--next", "plays the next song", False),
         ("--prev", "plays the previous song", False),
-        ("--openuri", "plays the track at the provided Uri", True),
+        ("--songuri", "plays the track at the provided Uri", True),
+        ("--listuri", "plays the playlist at the provided Uri", True),
     ]
 
 


### PR DESCRIPTION
Addresses:
 - Fixes #5
 - Potentially the start of addressing #15 by combining with some other service to get URI by artist/track and such, but that may be a stretch

With these new arguments, the user can provide a song or playlist URI to the CLI and it should play it.  The URI can be found by "sharing" a track from the Spotify app.  The URL will look like: 

```
https://open.spotify.com/track/0z5KIZSt0Vcm8diVg0WBjP?si=16c79071b0134c83
                               ^^^^^^^^^^^^^^^^^^^^^^
                                ^ Spotify URI Here ^
```

Maybe there's an easier way?  Anyway you can call it from the CLI like:

```
spotifycli --songuri 0z5KIZSt0Vcm8diVg0WBjP
```

or

```
spotifycli --listuri 37i9dQZF1DZ06evO0jO79m
```

And it plays just fine.  I'm totally open to adjusting the naming of the command line arguments as you prefer.

Note, this will have minor conflicts with if #85 is merged.  I'm happy to resolve them, just tell me what method you prefer for the squash/merge/rebase whatever and I can do it.