### PR TITLE
Added a clear command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,14 @@
 # spotify-cli-linux
 
- [![Build](https://github.com/pwittchen/spotify-cli-linux/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/pwittchen/spotify-cli-linux/actions/workflows/build.yml) 
- [![Deploy](https://github.com/pwittchen/spotify-cli-linux/actions/workflows/deploy.yml/badge.svg)](https://github.com/pwittchen/spotify-cli-linux/actions/workflows/deploy.yml)
- [![Version](https://img.shields.io/pypi/v/spotify-cli-linux.svg?style=flat-square)](https://pypi.python.org/pypi/spotify-cli-linux/)
+[![Build](https://github.com/pwittchen/spotify-cli-linux/actions/workflows/build.yml/badge.svg?branch=master)](https://github.com/pwittchen/spotify-cli-linux/actions/workflows/build.yml)
+[![Deploy](https://github.com/pwittchen/spotify-cli-linux/actions/workflows/deploy.yml/badge.svg)](https://github.com/pwittchen/spotify-cli-linux/actions/workflows/deploy.yml)
+[![Version](https://img.shields.io/pypi/v/spotify-cli-linux.svg?style=flat-square)](https://pypi.python.org/pypi/spotify-cli-linux/)
 
 A command line interface to [Spotify](https://www.spotify.com/) on Linux.
 
 If you're using macOS, see [spotify-cli-macos](https://github.com/pwittchen/spotify-cli-macos).
 
-installation
-------------
+## installation
 
 ```
 pip install spotify-cli-linux
@@ -27,8 +26,7 @@ cd spotify-cli-linux
 sudo cp spotifycli/spotifycli.py /usr/local/bin/spotifycli
 ```
 
-upgrade
--------
+## upgrade
 
 ```
 pip install spotify-cli-linux --upgrade
@@ -36,8 +34,7 @@ pip install spotify-cli-linux --upgrade
 
 for the upgrade, you can apply the same hints like for installation
 
-usage
------
+## usage
 
 start the official Spotify desktop app
 
@@ -69,6 +66,7 @@ use one of the following parameters:
 --playpause       plays or pauses the song (toggles a state)
 --next            plays the next song
 --prev            plays the previous song
+--clear           clear the terminal
 --songuri OPENURI plays the track at the provided Uri
 --listuri OPENURI plays the playlist at the provided Uri
 --client CLIENT   sets client's dbus name
@@ -76,8 +74,7 @@ use one of the following parameters:
 
 if you don't use any parameters, you'll enter the shell mode, where you'll be able to use all commands mentioned above
 
-solving problems
-----------------
+## solving problems
 
 ### lyriq
 
@@ -87,13 +84,11 @@ When, you're missing `lyriq` dependency, run the following command:
 pip install lyriq
 ```
 
-usage with tmux
----------------
+## usage with tmux
 
 If you want to use this script in your tmux panel, you can check [tmux-plugin-spotify](https://github.com/pwittchen/tmux-plugin-spotify).
 
-development
------------
+## development
 
 to install necessary tools for code formatting, static code analysis and releasing, run:
 
@@ -101,8 +96,7 @@ to install necessary tools for code formatting, static code analysis and releasi
 make requirements
 ```
 
-code formatting
----------------
+## code formatting
 
 Source code should be formatted according to [PEP8](https://www.python.org/dev/peps/pep-0008/) style guides.
 
@@ -118,8 +112,7 @@ to verify code formatting, type:
 make checkformat
 ```
 
-static code analysis
---------------------
+## static code analysis
 
 To run static code analysis, execute:
 
@@ -127,8 +120,7 @@ To run static code analysis, execute:
 make lint
 ```
 
-docs
-----
+## docs
 
 to update docs on `gh-pages`, type:
 
@@ -137,6 +129,7 @@ make docs
 ```
 
 to run docs locally, type:
+
 ```
 git checkout gh-pages && ./serve.sh
 ```
@@ -145,8 +138,7 @@ and view page with docs at: 0.0.0.0:8000
 
 view it on-line at https://pwittchen.github.io/spotify-cli-linux
 
-releasing
----------
+## releasing
 
 currently release is automated via `deploy.yml` GitHub Action, but it can be done manually too
 

--- a/spotifycli/spotifycli.py
+++ b/spotifycli/spotifycli.py
@@ -167,6 +167,7 @@ def get_arguments():
 def show_version():
     print("2.0.0")
 
+
 def clear_cli():
     os.system('cls' if os.name == 'nt' else 'clear')
 

--- a/spotifycli/spotifycli.py
+++ b/spotifycli/spotifycli.py
@@ -58,6 +58,8 @@ def main():
             show_lyrics()
         elif args.arturl:
             show_art_url()
+        elif args.clear:
+            clear_cli()
         elif args.play:
             perform_spotify_action("Play")
         elif args.pause:
@@ -156,6 +158,7 @@ def get_arguments():
         ("--lyrics", "shows the lyrics for the song"),
         ("--next", "plays the next song"),
         ("--prev", "plays the previous song"),
+        ("--clear", "clear the terminal"),
         ("--songuri", "plays the track at the provided Uri", True),
         ("--listuri", "plays the playlist at the provided Uri", True),
     ]
@@ -163,6 +166,9 @@ def get_arguments():
 
 def show_version():
     print("2.0.0")
+
+def clear_cli():
+    os.system('cls' if os.name == 'nt' else 'clear')
 
 
 def get_song():


### PR DESCRIPTION
**Add ``--clear`` command to clear the terminal.**

The reason for this PR com from the way I use ``spotifycli``. 
I typically run ``spotifycli`` in its interactive mode and execute commands like ``status``, ``lyrics``, etc. Over time, the terminal fills up with output, and there was no convenient way to clear it without exiting ``spotifycli``.

This change adds a ``--clear`` command that allows clearing the terminal without leaving the interactive session.
